### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Web-Developmen
 ## Table of Contents
 [Ultimate-Web-Development-Resources](#Ultimate-Web-Development-Resources)
 - [Web design softwares](#Web-design-softwares)
-- [Prototyping tools for UI/UX](#Prototyping-tools-for-UI/UX)
-- [Free Hoisting](#Free-Hoisting)
+- [Prototyping tools for UI/UX](#Prototyping-tools-for-UIUX)
+- [Free Hoisting](#Free-Hosting)
 - [Websites to learn](#Websites-to-learn)
 - [Websites for code challenges](#Websites-for-code-challenges)
 - [Web Images or Photos](#Web-Images-or-Photos)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Web-Developmen
 [Ultimate-Web-Development-Resources](#Ultimate-Web-Development-Resources)
 - [Web design softwares](#Web-design-softwares)
 - [Prototyping tools for UI/UX](#Prototyping-tools-for-UIUX)
-- [Free Hoisting](#Free-Hosting)
+- [Free Hosting](#Free-Hosting)
 - [Websites to learn](#Websites-to-learn)
 - [Websites for code challenges](#Websites-for-code-challenges)
 - [Web Images or Photos](#Web-Images-or-Photos)


### PR DESCRIPTION
Fixed 2 links at the top of the page:
 - Prototyping tools link didn't work because internal markdown links can't contain `/`
 - Free hosting link didn't work because of a typo.