### PR TITLE
Removed Heroku from Free Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Please see [CONTRIBUTING](https://github.com/DHANUSHXENO/Ultimate-Web-Developmen
 
 ## Free Hosting
 - [Vercel](https://vercel.com)
-- [Heroku](https://www.heroku.com)
 - [Amazon](https://aws.amazon.com)
 - [Netlify](https://www.netlify.com)
 - [Firebase](https://firebase.google.com)


### PR DESCRIPTION
Heroku no longer provides free hosting service. So removed it from "Free Hosting"