### PR TITLE
Updated broken/wrong links of the github pages website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# [Ultimate-Web-Development-Resources]([https://github.com/DhanushNehru/Ultimate-Web-Development-Resources](https://dhanushnehru.github.io/Ultimate-Web-Development-Resources/))
+# [Ultimate-Web-Development-Resources](https://dhanushnehru.github.io/Ultimate-Web-Development-Resources)
 
 A collection of Web Developement Resources at one place
 
-![Ultimate-Web-Development-Resources by Dhanush N](https://github.com/DhanushNehru/Ultimate-Web-Development-Resources/blob/main/cover.png)
+![Ultimate-Web-Development-Resources by Dhanush N](https://raw.githubusercontent.com/DhanushNehru/Ultimate-Web-Development-Resources/main/cover.png)
 
 ## Contributing
 


### PR DESCRIPTION
@DhanushNehru 
Issue #473 
I have fixed the two broken/wrong links in the github pages website which is deployed through the README.md file.

![Screenshot (23)](https://github.com/DhanushNehru/Ultimate-Web-Development-Resources/assets/96707067/263572ca-e971-48e9-af76-f3da2c65640b)

1. The link of the navbar section is broken, as you can see on the bottom where does clicking on the navbar take you.
2. The link of the banner image is wrong, as it contains the folder-link of that image rather than the actual image-link.

Kindly review my pull request and merge it please.