### PR TITLE
Fixed a Typo in merging of Title and link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-Web-Developme
 - [HTML Crash Course For Absolute Beginners - Traversy Media](https://www.youtube.com/watch?v=UB1O30fR-EE)
 - [HTML Tutorial - How to Make a Super Simple Website(Freecodecamp)](https://www.youtube.com/watch?v=PlxWf493en4)
 - [HTML & CSS Full Course - Beginner to Pro(SuperSimpleDev](https://www.youtube.com/watch?v=G3e-cpL7ofc&t=19628s)
-- [HTML: HyperText Markup Language] https://developer.mozilla.org/en-US/docs/Web/HTML
+- [HTML: HyperText Markup Language](https://developer.mozilla.org/en-US/docs/Web/HTML)
 
 
 ## CSS Learning Resources


### PR DESCRIPTION
in the recent addition of the HTML course, I found a typo where "()" was not used for covering the link which was not looking good in the preview of README.md, so I fixed it. hope it helps