### PR TITLE
Add Cloudflare Pages/Workers to the Free Hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-Web-Developme
 - [Supabase](https://supabase.com)
 - [Glitch](https://glitch.com/)
 - [Fleek](https://fleek.co/)
+- [Cloudflare Pages](https://pages.cloudflare.com)
+- [Cloudflare Workers](https://workers.cloudflare.com)
 
 
 ## Websites to learn


### PR DESCRIPTION
I'm adding them as 2 separate links since they're technically 2 different kinds of hosting services. Workers is for hosting serverless functions and Pages is for hosting websites (but it uses Workers internally).

- [Cloudflare Pages](https://pages.cloudflare.com/)
- [Cloudflare Workers](https://workers.cloudflare.com/)

I don't want to create 2 separate pull requests since it's kind of overkill.