### PR TITLE
added 2 more website for Website Copier

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-Web-Developme
 
 - [Httrack](https://www.httrack.com/)
 - [Cyotek WebCopy](https://www.cyotek.com/cyotek-webcopy)
+- [GNU Wget](https://www.gnu.org/software/wget/)
+- [WebCopy by Cyotek](https://www.cyotek.com/cyotek-webcopy)
 
 
 ## HTML Learning Resources


### PR DESCRIPTION
1.WebCopy by Cyotek:
Cyotek WebCopy, as mentioned earlier, is a reliable and user-friendly tool for copying websites. It's designed for Windows users and provides options for downloading entire websites or specific parts of them.


2.GNU Wget:

GNU Wget is a command-line utility for downloading files from the web. While it's not as user-friendly as some other tools, it's highly versatile and can be used to copy entire websites. It's available for various platforms, including Linux, Windows, and macOS.