### PR TITLE
Add new site to websites to learn and code challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-Web-Developme
 - [Stack Overflow](https://stackoverflow.com/)
 - [Tutorialspoint](https://tutorialspoint.com/)
 - [Scaler](https://www.scaler.com/blog/)
+- [LabEx](https://labex.io)
 
 ## Websites for code challenges
 
@@ -181,6 +182,7 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-Web-Developme
 - [InterviewBit](https://www.interviewbit.com/practice/)
 - [JavaScript30](https://javascript30.com/)
 - [KodeKloud](https://kodekloud.com/kodekloud-engineer/)
+- [LabEx Interview Questions](https://labex.io/interview-questions)
 - [Leet Code](http://leetcode.com)
 - [Project Euler](http://projecteuler.net)
 - [Sphere Online Judge](http://spoj.com)


### PR DESCRIPTION
Add LabEx to websites to learn and code challenges

I work at LabEx, a unique learning platform that has delivered over 2,000 hands-on interview questions over the past seven years. Unlike algorithm-focused online judge platforms, LabEx offers free hands-on interview questions in Linux, DevOps, and Cybersecurity. It provides an online hands-on environment where users can practice online and automatically validate their solutions.

This repo is a great resource. Please let me know if any changes are needed.