### PR TITLE
Add workflow to welcome new issues

### DIFF
--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,36 @@
+# A name for the workflow, which will be displayed in the Actions tab
+name: Welcome New Issues 👋
+
+# This section defines the trigger for the workflow
+on:
+  issues:
+    types: [opened] # The workflow only runs when a new issue is opened
+
+# These are the permissions the workflow needs to operate
+permissions:
+  issues: write # Grants permission to write comments on issues
+
+# This section defines the jobs to be executed
+jobs:
+  post-welcome-comment:
+    runs-on: ubuntu-latest # The job will run on a virtual machine with the latest Ubuntu OS
+    steps:
+      # This step uses a pre-made action to execute a script
+      - name: Add welcome comment
+        uses: actions/github-script@v7
+        with:
+          # The GITHUB_TOKEN is automatically created and is used for authentication
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // This is the message that will be posted as a comment
+            const message = `Thank you for raising this issue! Our team will review it soon. 
+            
+            For more queries or discussions or approval of requests, please join the Discord server for further discussion: [Discord Link](https://discord.com/invite/Yn9g6KuWyA)`;
+
+            // This is the API call that posts the comment to the new issue
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow that automatically welcomes contributors when they create a new issue. This helps improve community engagement by providing immediate feedback and directing contributors to the Discord server for further discussion.

**Changes Implemented:**
- Created a new workflow file at .github/workflows/issue-auto-reply.yml.
- The workflow is configured to trigger only on the issues: opened event.
- It uses the actions/github-script to post a welcome message, as defined in the project requirements.

Closes #588